### PR TITLE
Favorite eateries fix

### DIFF
--- a/prisma/migrations/20260226190507_use_cornellid_for_favorites/migration.sql
+++ b/prisma/migrations/20260226190507_use_cornellid_for_favorites/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - The primary key for the `FavoritedEatery` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `eateryId` on the `FavoritedEatery` table. All the data in the column will be lost.
+  - Added the required column `cornellId` to the `FavoritedEatery` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "FavoritedEatery" DROP CONSTRAINT "FavoritedEatery_eateryId_fkey";
+
+-- AlterTable
+ALTER TABLE "Eatery" ALTER COLUMN "announcements" SET DEFAULT ARRAY[]::TEXT[];
+
+-- AlterTable
+ALTER TABLE "FavoritedEatery" DROP CONSTRAINT "FavoritedEatery_pkey",
+DROP COLUMN "eateryId",
+ADD COLUMN     "cornellId" INTEGER NOT NULL,
+ADD CONSTRAINT "FavoritedEatery_pkey" PRIMARY KEY ("userId", "cornellId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,12 +64,11 @@ model User {
 }
 
 model FavoritedEatery {
-  user     User   @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId   Int
-  eatery   Eatery @relation(fields: [eateryId], references: [id])
-  eateryId Int
+  user      User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    Int
+  cornellId Int  // Stable eatery identifier that persists across scrapes
 
-  @@id([userId, eateryId])
+  @@id([userId, cornellId])
 }
 
 model FCMToken {
@@ -120,9 +119,8 @@ model Eatery {
   eateryTypes    EateryType[]
   createdAt      DateTime        @default(now())
 
-  events            Event[]
-  favoritedEateries FavoritedEatery[]
-  reports           Report[]
+  events  Event[]
+  reports Report[]
 }
 
 model Event {

--- a/src/users/userController.ts
+++ b/src/users/userController.ts
@@ -139,7 +139,7 @@ export const addFavoriteEatery = async (
   next: NextFunction,
 ) => {
   try {
-    const { eateryId } = req.body;
+    const { cornellId } = req.body;
     const { userId } = req.user!;
 
     const user = await prisma.user.findUnique({
@@ -153,14 +153,14 @@ export const addFavoriteEatery = async (
     // Use upsert to avoid crashing if the relation already exists
     await prisma.favoritedEatery.upsert({
       where: {
-        userId_eateryId: {
+        userId_cornellId: {
           userId: user.id,
-          eateryId: eateryId,
+          cornellId: cornellId,
         },
       },
       create: {
         userId: user.id,
-        eateryId: eateryId,
+        cornellId: cornellId,
       },
       update: {},
     });
@@ -177,7 +177,7 @@ export const removeFavoriteEatery = async (
   _next: NextFunction,
 ) => {
   try {
-    const { eateryId } = req.body;
+    const { cornellId } = req.body;
     const { userId } = req.user!;
 
     const user = await prisma.user.findUnique({
@@ -188,9 +188,9 @@ export const removeFavoriteEatery = async (
     }
     await prisma.favoritedEatery.delete({
       where: {
-        userId_eateryId: {
+        userId_cornellId: {
           userId: user.id,
-          eateryId: eateryId,
+          cornellId: cornellId,
         },
       },
     });

--- a/src/users/users.schema.ts
+++ b/src/users/users.schema.ts
@@ -14,6 +14,6 @@ export const favoriteItemSchema = z.object({
 
 export const favoriteEaterySchema = z.object({
   body: z.object({
-    eateryId: z.number().int().positive('eateryId must be a positive integer'),
+    cornellId: z.number().int('cornellId must be an integer'),
   }),
 });


### PR DESCRIPTION
## Overview
Changed favorited eateries to use cornell id rather than eatery object

## Changes Made
Scraper would delete Eatery rows while FavoritedEatery still referenced them, so switched to using cornellId for favoriting eateries

## Test Coverage
Tested locally