### PR TITLE
Warn instead of crashing when scraper encounters unknown enum values

### DIFF
--- a/prisma/mappers.ts
+++ b/prisma/mappers.ts
@@ -32,7 +32,8 @@ export function mapCampusArea(area: RawCampusArea): CampusArea {
     case 'South':
       return CampusArea.SOUTH;
     default:
-      throw new Error(`Unknown campus area: ${area.descrshort}`);
+      console.warn(`Unknown campus area: ${area.descrshort}, defaulting to CENTRAL`);
+      return CampusArea.CENTRAL;
   }
 }
 
@@ -53,7 +54,8 @@ export function mapPaymentMethod(method: RawPayMethod): PaymentMethod {
     case 'Free':
       return PaymentMethod.FREE;
     default:
-      throw new Error(`Unknown payment method: ${method.descrshort}`);
+      console.warn(`Unknown payment method: ${method.descrshort}, defaulting to CARD`);
+      return PaymentMethod.CARD;
   }
 }
 
@@ -75,7 +77,8 @@ export function mapEateryType(type: RawEateryType): EateryType {
     case 'General':
       return EateryType.GENERAL;
     default:
-      throw new Error(`Unknown eatery type: ${type.descr}`);
+      console.warn(`Unknown eatery type: ${type.descr}, defaulting to GENERAL`);
+      return EateryType.GENERAL;
   }
 }
 
@@ -107,7 +110,8 @@ export function mapEventType(eventDescription: string): EventType {
     case 'Free Food':
       return EventType.GENERAL;
     default:
-      throw new Error(`Unknown event type: ${eventDescription}`);
+      console.warn(`Unknown event type: ${eventDescription}, defaulting to GENERAL`);
+      return EventType.GENERAL;
   }
 }
 

--- a/prisma/scraper.ts
+++ b/prisma/scraper.ts
@@ -385,6 +385,12 @@ async function transformEateriesConcurrently(
   }
 
   if (errors.length > 0) {
+    const failureRate = errors.length / rawEateries.length;
+    if (failureRate >= 0.5) {
+      throw new Error(
+        `Aborting: ${errors.length}/${rawEateries.length} API eateries failed to transform (${Math.round(failureRate * 100)}%)`,
+      );
+    }
     console.warn(
       `Skipped ${errors.length} API eatery(ies) due to transform errors`,
     );

--- a/prisma/scraper.ts
+++ b/prisma/scraper.ts
@@ -385,11 +385,8 @@ async function transformEateriesConcurrently(
   }
 
   if (errors.length > 0) {
-    const errorMessages = errors
-      .map((e) => `Eatery "${e.eatery.name}": ${e.error}`)
-      .join('\n');
-    throw new Error(
-      `Failed to transform ${errors.length} eatery(ies):\n${errorMessages}`,
+    console.warn(
+      `Skipped ${errors.length} API eatery(ies) due to transform errors`,
     );
   }
 


### PR DESCRIPTION
## Overview

The scraper was crashing when Cornell's API changed and returned an unrecognized value (which last time was a new payment method), leaving menus out of date. Unknown enum values now leave warnings instead of crashing the scraper, and fall back to a default value.

## Changes Made

- mappers.ts: replaced specific errors with console.warn and default values
	- mapPaymentMethod (default to CARD)
	- mapEventType (default to GENERAL)
	- mapEateryType (default to GENERAL)
	- mapCampusArea (default to CENTRAL)
- scraper.ts: errors on individual eatery don't crash the whole thing, instead, they are skipped and the failure is logged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data processing resilience. The system now gracefully handles invalid values and transformation errors by logging warnings and continuing with valid data, rather than failing the entire operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cuappdev/eatery-blue-backend/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->